### PR TITLE
Fix Coinkite URL on Donation log

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,4 +94,4 @@ donate bc1qh4f9t2gp2mhy0fqz4k6a4yh6krvd792ecswfxy
 <b>donation log:</b>
 <ul>
      <li> 2021-09-06 06:24 0.02499808 Bounty Paid to @achow101
-     <li> 2021-09-02 9:25 0.025 BTC by <a href="coinkite.com">Coinkite</a>
+     <li> 2021-09-02 9:25 0.025 BTC by <a href="https://coinkite.com">Coinkite</a>


### PR DESCRIPTION
Currently a `404`:

![image](https://user-images.githubusercontent.com/177608/134280526-db98e1db-5766-4127-a416-1cbd79a4cf72.png)

![image](https://user-images.githubusercontent.com/177608/134280587-8b2df5cc-9b8a-41f5-b3fe-9dd691b52101.png)
