### PR TITLE
Twitter bot for builds

### DIFF
--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -154,23 +154,30 @@ jobs:
 
       - name: Commit updates
         run: |
-          # Append each new output line to the HTML table
-          for o in `ls artifacts/*/*output.txt` ; do
-            TEXT=`cat ${o}` ;
-            perl -pi -e "s+^<ul class=\"log\">$+<ul class=\"log\">\n     ${TEXT}+" index.html ;
-          done
+          PATTERN="artifacts/*/*output.txt"
 
-          # Check in each new video artifact
-          for dir in `ls -d artifacts/*` ; do
-            p=`echo ${dir} | cut -f 2 -d '/'`
-            mv artifacts/${p}/${p}*-video.webm ${p}/ ;
-            git add ${p}/*-video.webm ;
-          done
+          # Run only if any artifacts were found
+          if ls $PATTERN 1> /dev/null 2>&1; then
+              # Append each new output line to the HTML table
+              for o in `ls artifacts/*/*output.txt` ; do
+                TEXT=`cat ${o}` ;
+                perl -pi -e "s+^<ul class=\"log\">$+<ul class=\"log\">\n     ${TEXT}+" index.html ;
+              done
 
-          git add index.html
-          git config --local user.email 'action@github.com'
-          git config --local user.name 'GitHub Action'
-          git commit -m 'Add latest build artifacts'
+              # Check in each new video artifact
+              for dir in `ls -d artifacts/*` ; do
+                p=`echo ${dir} | cut -f 2 -d '/'`
+                mv artifacts/${p}/${p}*-video.webm ${p}/ ;
+                git add ${p}/*-video.webm ;
+              done
+
+              git add index.html
+              git config --local user.email 'action@github.com'
+              git config --local user.name 'GitHub Action'
+              git commit -m 'Add latest build artifacts'
+          else
+              echo "No new artifacts to commit"
+          fi
 
       - name: Push updates
         uses: ad-m/github-push-action@master

--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -127,8 +127,25 @@ jobs:
             xterm -display $DISPLAY -e "cd ${REPO_ROOT_DIR}/${PROJECT} && ./steps.sh 2>&1 | tee log.out"
             # wait for steps to run
             pkill -f ffmpeg
+
+            # Convert video to mp4 for Twitter upload
+            ffmpeg -nostats -y -i ${PROJECT}-${VERSION}-video.webm -movflags faststart -pix_fmt yuv420p ${PROJECT}-${VERSION}-video.mp4
+            ORIGINAL_DURATION=$(ffprobe -i ${PROJECT}-${VERSION}-video.mp4 -show_entries format=duration -v quiet -of csv="p=0")
+          
+            if [[ $ORIGINAL_DURATION > 140 ]]; then
+                mv ${PROJECT}-${VERSION}-video.mp4 ${PROJECT}-${VERSION}-video-original.mp4
+                echo "Original video is longer than 140 seconds, so we will speed it up for Twitter."
+                ffmpeg -nostats -y -i ${PROJECT}-${VERSION}-video-original.mp4 -movflags faststart -pix_fmt yuv420p -filter:v "setpts=(139/${ORIGINAL_DURATION})*PTS" ${PROJECT}-${VERSION}-video.mp4
+            fi
+
             ./artifacts.sh >> ${PROJECT}-output.txt
             cat log.out
+
+            # Create a txt file artifact that forms part of the tweet composed in reproTweet step.
+            TWITTER_NAME=`perl -ne 'print "$1\n" if /^TWITTER_NAME="?([^"]*)"?$/' artifacts.sh`
+            if [ ! -z "$TWITTER_NAME" ]; then
+                echo "${TWITTER_NAME} ${VERSION}" > "${PROJECT}-${VERSION}-tweet-entry.txt"
+            fi
           fi ;
 
       - name: Stage ${{ matrix.project }} artifacts
@@ -137,7 +154,9 @@ jobs:
           name: ${{ matrix.project }}
           path: |
             ${{ matrix.project }}/${{ matrix.project }}*-video.webm
+            ${{ matrix.project }}/${{ matrix.project }}*-video.mp4
             ${{ matrix.project }}/${{ matrix.project }}-output.txt
+            ${{ matrix.project }}/${{ matrix.project }}*-tweet-entry.txt
 
   reproCommit:
     needs:
@@ -183,3 +202,58 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  reproTweet:
+    needs:
+      - reproCommit
+    runs-on: ubuntu-latest
+    env:
+      TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+      TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+      TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+      TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Gather artifacts from jobs
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Tweet about new builds
+        working-directory: twitter_bot
+        run: |
+          PATTERN="../artifacts/*/*tweet-entry.txt"
+
+          if ls $PATTERN 1> /dev/null 2>&1; then
+              pip install -q -r requirements.txt
+
+              for t in `ls $PATTERN` ; do
+                PROJECT=$(echo "$t" | sed -e 's/..\/artifacts\///g' -e 's/\/.*//g')
+                VERSION=$(echo "$t" | sed -e 's/..\/artifacts\/[a-zA-Z]*\/[a-zA-z]*-//g' -e 's/.*\///g' -e 's/-tweet-entry.txt//g')
+
+                MP4_VIDEO_FILENAME="${t/tweet-entry.txt/video.mp4}"
+                WEBM_VIDEO_URL="https://github.com/${GITHUB_REPOSITORY}/raw/${GITHUB_REF_NAME}/${PROJECT}/${PROJECT}-${VERSION}-video.webm"
+                
+                printf "New successful build on bitcoinbinary.org!\n\n" > tweet.txt
+                printf "`cat ${t}`\n\n" >> tweet.txt
+                printf "Original video proof: $WEBM_VIDEO_URL\n" >> tweet.txt
+
+                echo
+                echo "Tweeting the following:"
+                echo "---------------------------------"
+                cat tweet.txt
+                echo "---------------------------------"
+                echo
+
+                python send_tweet.py tweet.txt $MP4_VIDEO_FILENAME $WEBM_VIDEO_URL
+              done
+          else
+              echo "No new successful builds to tweet (or TWITTER_NAME not set in artifacts.sh)."
+          fi

--- a/bitbox02-firmware/artifacts.sh
+++ b/bitbox02-firmware/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="BitBox02"
 URL="https://shiftcrypto.ch/bitbox02/"
 VERSION="firmware-btc-only/v9.11.0"
 REPO="https://github.com/digitalbitbox/bitbox02-firmware"

--- a/bitcoin-core/artifacts.sh
+++ b/bitcoin-core/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="Bitcoin Core"
 VERSION="v23.0"
 URL="https://bitcoin.org/"
 REPO="https://github.com/bitcoin/bitcoin"

--- a/blockstream-green/artifacts.sh
+++ b/blockstream-green/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="@Blockstream Green"
 URL="https://blockstream.com/"
 VERSION="3.8.5"
 VERSION_STRING="release_${VERSION}"

--- a/coldcard-mk3/artifacts.sh
+++ b/coldcard-mk3/artifacts.sh
@@ -3,6 +3,7 @@
 find ./firmware -type f -name firmware*.bin >&2
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="@COLDCARDwallet Mk3"
 VERSION=4.1.5
 VERSION_STRING="2022-05-04T1258-v${VERSION}"
 URL="https://coldcard.com"

--- a/coldcard/artifacts.sh
+++ b/coldcard/artifacts.sh
@@ -3,6 +3,7 @@
 find ./firmware -type f -name firmware*.bin >&2
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="@COLDCARDwallet Mk4"
 VERSION=5.0.6
 VERSION_STRING="2022-07-29T1817-v${VERSION}"
 URL="https://coldcard.com"

--- a/lnd/artifacts.sh
+++ b/lnd/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="LND"
 VERSION="v0.15.0-beta"
 URL="https://lightning.network/"
 REPO="https://github.com/lightningnetwork/lnd"

--- a/mycelium-android/artifacts.sh
+++ b/mycelium-android/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="Mycelium Wallet"
 URL="https://wallet.mycelium.com/"
 VERSION="v3.15.0.0"
 REPO="https://github.com/mycelium-com/wallet-android"

--- a/simple-bitcoin-wallet/artifacts.sh
+++ b/simple-bitcoin-wallet/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="@SimpleBtcWallet"
 URL="https://sbw.app/"
 VERSION="2.4.27"
 REPO="https://github.com/btcontract/wallet"

--- a/sparrow/artifacts.sh
+++ b/sparrow/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="@SparrowWallet"
 URL="https://sparrowwallet.com/"
 VERSION="1.6.6"
 REPO="https://github.com/sparrowwallet/sparrow"

--- a/trezor-firmware/artifacts.sh
+++ b/trezor-firmware/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="@Trezor"
 VERSION="2.5.1"
 VERSION_STRING="core/v${VERSION}"
 URL="https://trezor.io/"

--- a/twitter_bot/authorize.py
+++ b/twitter_bot/authorize.py
@@ -1,0 +1,25 @@
+# This script can be used to get the access token and access token secret for the bot.
+#
+# It's useful when your Twitter Developer account is associated to one account
+# but you need to use another account to send the tweets
+#
+# See: https://docs.tweepy.org/en/stable/authentication.html?#pin-based-oauth
+
+import tweepy
+
+api_key = input("Enter the API key of your Twitter app: ")
+api_secret = input("Enter the API secret of your Twitter app: ")
+
+oauth1_user_handler = tweepy.OAuth1UserHandler(api_key, api_secret, callback="oob")
+
+print(
+    "Go to the following URL to authorize your app to act as another Twitter account: "
+    + oauth1_user_handler.get_authorization_url()
+)
+
+verifier = input("Enter verification PIN you got from the authorization page: ")
+
+access_token, access_token_secret = oauth1_user_handler.get_access_token(verifier)
+
+print("Access token: " + access_token)
+print("Access token secret: " + access_token_secret)

--- a/twitter_bot/requirements.txt
+++ b/twitter_bot/requirements.txt
@@ -1,0 +1,9 @@
+certifi==2022.6.15
+charset-normalizer==2.1.0
+idna==3.3
+oauthlib==3.2.0
+protobuf==4.21.5
+requests==2.28.1
+requests-oauthlib==1.3.1
+tweepy==4.10.0
+urllib3==1.26.11

--- a/twitter_bot/send_tweet.py
+++ b/twitter_bot/send_tweet.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import tweepy
+
+tweet_file = open(sys.argv[1], "r")
+tweet_text = tweet_file.read()
+
+video_file = open(sys.argv[2], "r")
+
+auth = tweepy.OAuth1UserHandler(
+    os.environ["TWITTER_API_KEY"],
+    os.environ["TWITTER_API_SECRET"],
+    os.environ["TWITTER_ACCESS_TOKEN"],
+    os.environ["TWITTER_ACCESS_TOKEN_SECRET"],
+)
+
+api = tweepy.API(auth)
+
+upload_result = api.media_upload(filename=sys.argv[2], media_category="tweet_video")
+
+print("Video upload result:", upload_result)
+
+if upload_result.processing_info["state"] == "succeeded":
+    api.update_status(status=tweet_text, media_ids=[upload_result.media_id])
+else:
+    api.update_status(status=tweet_text)

--- a/wasabi/artifacts.sh
+++ b/wasabi/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="@wasabiwallet"
 URL="https://wasabiwallet.io/"
 VERSION="v2.0.1.2"
 REPO="https://github.com/zkSNACKs/WalletWasabi"

--- a/zap-android/artifacts.sh
+++ b/zap-android/artifacts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DATE=`date +%Y-%m-%d`
+TWITTER_NAME="@ln_zap"
 URL="http://zaphq.io/"
 VERSION="0.5.6-beta"
 VERSION_STRING="v${VERSION}"


### PR DESCRIPTION
Addresses issue #43. Also adds an additional check in `reproCommit` step, so it doesn't fail when there is nothing to commit.

* One tweet per build.
* Converts WebM video to mp4 as Twitter doesn't support the former.
* If required, speeds up mp4 video, so it fits into Twitter's 140 second limit.
* `TWITTER_NAME` in `artifacts.sh` files determines how the project is referenced in the tweet.
* Wasn't sure how to handle @'ing the contributor...

Required for setup:

* Twitter developer account and an app with permissions to send tweets.
* The following secrets added to the repo (see `authorize.py` helper script for obtaining the access token and secret):
  * `TWITTER_API_KEY`
  * `TWITTER_API_SECRET`
  * `TWITTER_ACCESS_TOKEN`
  * `TWITTER_ACCESS_TOKEN_SECRET`

See [example run](https://github.com/siim-m/bitcoinbinary.org/actions/runs/2854601558) in my forked repo – the latest entries for COLDCARD and Sparrow were removed for testing.

<img width="598" alt="image" src="https://user-images.githubusercontent.com/46551195/184523874-e058ae82-3423-4414-8c5b-84c14f8d3d3a.png">
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/46551195/184523906-e0eca96f-35fd-4c46-9021-5bea180d8282.png">
