### PR TITLE
Bump Blockstream Green version and fix Twitter video bug

### DIFF
--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -134,8 +134,6 @@ jobs:
             # Convert to integer format, so bash can do arithmetic
             ORIGINAL_DURATION=$(echo $ORIGINAL_DURATION | sed -e 's/\.[0-9]*//')
 
-            echo "Duration of video: ${ORIGINAL_DURATION}"
-
             if (( $ORIGINAL_DURATION > 140 )); then
                 mv ${PROJECT}-${VERSION}-video.mp4 ${PROJECT}-${VERSION}-video-original.mp4
                 echo "Original video is longer than 140 seconds, so we will speed it up for Twitter."

--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -131,10 +131,12 @@ jobs:
             # Convert video to mp4 for Twitter upload
             ffmpeg -nostats -y -i ${PROJECT}-${VERSION}-video.webm -movflags faststart -pix_fmt yuv420p ${PROJECT}-${VERSION}-video.mp4
             ORIGINAL_DURATION=$(ffprobe -i ${PROJECT}-${VERSION}-video.mp4 -show_entries format=duration -v quiet -of csv="p=0")
+            # Convert to integer format, so bash can do arithmetic
+            ORIGINAL_DURATION=$(echo $ORIGINAL_DURATION | sed -e 's/\.[0-9]*//')
 
             echo "Duration of video: ${ORIGINAL_DURATION}"
 
-            if [[ $ORIGINAL_DURATION > 140 ]]; then
+            if (( $ORIGINAL_DURATION > 140 )); then
                 mv ${PROJECT}-${VERSION}-video.mp4 ${PROJECT}-${VERSION}-video-original.mp4
                 echo "Original video is longer than 140 seconds, so we will speed it up for Twitter."
                 ffmpeg -nostats -y -i ${PROJECT}-${VERSION}-video-original.mp4 -movflags faststart -pix_fmt yuv420p -filter:v "setpts=(139/${ORIGINAL_DURATION})*PTS" ${PROJECT}-${VERSION}-video.mp4

--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -131,7 +131,9 @@ jobs:
             # Convert video to mp4 for Twitter upload
             ffmpeg -nostats -y -i ${PROJECT}-${VERSION}-video.webm -movflags faststart -pix_fmt yuv420p ${PROJECT}-${VERSION}-video.mp4
             ORIGINAL_DURATION=$(ffprobe -i ${PROJECT}-${VERSION}-video.mp4 -show_entries format=duration -v quiet -of csv="p=0")
-          
+
+            echo "Duration of video: ${ORIGINAL_DURATION}"
+
             if [[ $ORIGINAL_DURATION > 140 ]]; then
                 mv ${PROJECT}-${VERSION}-video.mp4 ${PROJECT}-${VERSION}-video-original.mp4
                 echo "Original video is longer than 140 seconds, so we will speed it up for Twitter."

--- a/blockstream-green/artifacts.sh
+++ b/blockstream-green/artifacts.sh
@@ -3,7 +3,7 @@
 DATE=`date +%Y-%m-%d`
 TWITTER_NAME="@Blockstream Green"
 URL="https://blockstream.com/"
-VERSION="3.8.5"
+VERSION="3.8.6"
 VERSION_STRING="release_${VERSION}"
 REPO="https://github.com/Blockstream/green_android"
 CHECKSUM_SOURCE="https://github.com/Blockstream/green_android/releases/tag/${VERSION_STRING}"


### PR DESCRIPTION
Video speedup for Twitter did not work as the duration was being compared as string instead of integer.

Working now:

<img width="603" alt="image" src="https://user-images.githubusercontent.com/46551195/185038764-150139a9-54f9-4878-a0b7-7e15bb4df741.png">
