### PR TITLE
Added Core Lightning to repo

### DIFF
--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Working: coldcard, lnd, bitcoin-core, mycelium-android, zap-android, simple-bitcoin-wallet, wasabi, sparrow, blockstream-green
         # WIP: trezor-firmware, bitbox02-firmware
-        project: [coldcard, coldcard-mk3, lnd, bitcoin-core, mycelium-android, zap-android, simple-bitcoin-wallet, wasabi, sparrow, blockstream-green, fulcrum, electrs]
+        project: [coldcard, coldcard-mk3, lnd, bitcoin-core, mycelium-android, zap-android, simple-bitcoin-wallet, wasabi, sparrow, blockstream-green, fulcrum, electrs, cln]
     steps:
       - name: Setup xvfb for video capture
         run: |
@@ -124,6 +124,11 @@ jobs:
         if: ${{ matrix.project == 'fulcrum' }}
         run: |
           sudo apt install -y openssl git build-essential pkg-config zlib1g-dev libbz2-dev libjemalloc-dev libzmq3-dev qtbase5-dev qt5-qmake
+
+      - name: Setup deps for Core Lightning
+        if: ${{ matrix.project == 'cln' }}
+        run: |
+          sudo apt install -y autoconf automake build-essential ca-certificates curl dirmngr gettext gnupg libpq-dev libtool libffi-dev python3 python3-dev python3-mako python3-pip python3-venv python3-setuptools wget zlib1g libgmp-dev unzip tclsh rustc
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/cln/artifacts.sh
+++ b/cln/artifacts.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+DATE=$(date +%Y-%m-%d)
+TWITTER_NAME="@Core_LN"
+VERSION="0.12.0"
+VERSION_STRING="v${VERSION}"
+REPO="https://github.com/ElementsProject/lightning"
+CHECKSUM_SOURCE="https://github.com/ElementsProject/lightning/releases/download/${VERSION_STRING}/SHA256SUMS"
+PROJECT="cln"
+SHA256=$(shasum -a 256 lightning/lightningd/lightningd | cut -f 1 -d ' ')
+
+# Note GITHUB_ environment variables are populated by Github Actions
+ARTIFACT_BASEURL="https://github.com/${GITHUB_REPOSITORY}/raw"
+ARTIFACT_BRANCH=${GITHUB_REF_NAME}
+
+ENTRY_TO_APPEND="<li><a href='${REPO}/releases/tag/${VERSION_STRING}'>${DATE}</a> | <a href='${URL}' class='project-name'>${PROJECT}</a>  | <a href='${REPO}/releases/tag/${VERSION_STRING}'>v${VERSION}</a> | <a href='${CHECKSUM_SOURCE}'> factory ${SHA256} </a>| <a href='${ARTIFACT_BASEURL}/${ARTIFACT_BRANCH}/${PROJECT}/${PROJECT}-${VERSION}-video.webm'>video proof</a> | <a href='https://github.com/coinkite/bitcoinbinary.org/blob/main/${PROJECT}/artifacts.sh' class="bot">build bot</a></li>"
+
+echo ${ENTRY_TO_APPEND}

--- a/cln/steps.sh
+++ b/cln/steps.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Pull in version numbers from artifacts.sh
+eval "$(grep VERSION_STRING artifacts.sh)"
+
+if [ ! -e cln ]; then
+	# Checkout source and submodules
+	git clone --progress https://github.com/ElementsProject/lightning.git
+fi
+# build motivated from the CLN's build Dockerfile, https://github.com/ElementsProject/lightning/blob/master/Dockerfile
+export TZ=America/Los_Angeles
+
+# install specific version of sqlite
+wget -q https://www.sqlite.org/2019/sqlite-src-3290000.zip \
+	&& unzip sqlite-src-3290000.zip \
+	&& cd sqlite-src-3290000 \
+	&& ./configure --enable-static --disable-readline --disable-threadsafe --disable-load-extension \
+	&& sudo make \
+	&& sudo make install && cd .. && rm sqlite-src-3290000.zip && rm -rf sqlite-src-3290000
+
+cd lightning
+git checkout ${VERSION_STRING}
+
+pip install poetry
+poetry config virtualenvs.create false
+poetry install
+./configure
+pwd
+make clean
+make
+cd ..
+./lightning/lightningd/lightningd --version
+shasum -a 256 lightning/lightningd/lightningd
+
+# Add delay for results to be printed and recorded
+sleep 10


### PR DESCRIPTION
## Why 
This PR adds [Core Lightning](https://twitter.com/Core_LN) builds to the repo. I borrowed motivation for the workflow environment directly from CLN's [Dockerfile](https://github.com/ElementsProject/lightning/blob/master/Dockerfile#L48:L71). 

The forked CI/CD workflow yielded an artifact with shasum included
```html
<li><a href='https://github.com/ElementsProject/lightning/releases/tag/v0.12.0'>2022-09-12</a> | <a href='' class='project-name'>cln</a> | <a href='https://github.com/ElementsProject/lightning/releases/tag/v0.12.0'>v0.12.0</a> | <a href='https://github.com/ElementsProject/lightning/releases/download/v0.12.0/SHA256SUMS'> factory e44851d9995e822cf44370bcf99a37cbc152a8fd2c861cad5fc922b3d8379f3f </a>| <a href='https://github.com/caheredia/bitcoinbinary.org/raw/add_CLN/cln/cln-0.12.0-video.webm'>video proof</a> | <a href='https://github.com/coinkite/bitcoinbinary.org/blob/main/cln/artifacts.sh' class=bot>build bot</a></li>
```
See all CI/CD artifacts [here](https://github.com/caheredia/bitcoinbinary.org/actions/runs/3034668282).

## What 
- I added a version command at the end of `steps.sh`. The video should show the build version and the shasum hash.
<img width="1387" alt="Screen Shot 2022-09-11 at 9 45 28 PM" src="https://user-images.githubusercontent.com/28638529/189576737-abee54e6-dd2e-498c-b100-d8a88252d61c.png">

- Added Core Lightning to repo