### PR TITLE
support Git LFS on Actions workflow

### DIFF
--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Checkout source
         uses: actions/checkout@v2
+        with:
+          lfs: true
 
       - name: Install ARM toolchain
         if: ${{ matrix.project == 'coldcard' || matrix.project == 'coldcard-mk3' || matrix.project == 'trezor-firmware' || matrix.project == 'bitbox02-firmware' }}


### PR DESCRIPTION
This procedure must be done by someone with the ability to rewrite the entire history:

https://github.com/coinkite/bitcoinbinary.org/issues/58#issuecomment-1288178825

After that, this small change will ensure all future .webm files will be pushed to Git LFS storage automatically.

An example of an action running fine after these two measures (the command above + this commit): https://github.com/fiatjaf/bitcoinbinary.alt/actions/runs/3308201814