### PR TITLE
Update bitbox build

### DIFF
--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         # Working: coldcard, lnd, bitcoin-core, mycelium-android, zap-android, simple-bitcoin-wallet, wasabi, sparrow, blockstream-green
-        # WIP: trezor-firmware, bitbox02-firmware
-        project: [coldcard, coldcard-mk3, lnd, bitcoin-core, mycelium-android, zap-android, simple-bitcoin-wallet, wasabi, sparrow, blockstream-green, fulcrum, electrs, cln, poncho]
+        # WIP: trezor-firmware 
+        project: [coldcard, coldcard-mk3, lnd, bitcoin-core, mycelium-android, zap-android, simple-bitcoin-wallet, wasabi, sparrow, blockstream-green, fulcrum, electrs, cln, poncho, bitbox02-firmware]
     steps:
       - name: Setup xvfb for video capture
         run: |
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install ARM toolchain
-        if: ${{ matrix.project == 'coldcard' || matrix.project == 'coldcard-mk3' || matrix.project == 'trezor-firmware' || matrix.project == 'bitbox02-firmware' }}
+        if: ${{ matrix.project == 'coldcard' || matrix.project == 'coldcard-mk3' || matrix.project == 'trezor-firmware'}}
         uses: carlosperate/arm-none-eabi-gcc-action@v1
         with:
           release: 'latest'
@@ -54,29 +54,7 @@ jobs:
 
       - name: Setup deps for BitBox02 firmware
         if: ${{ matrix.project == 'bitbox02-firmware' }}
-        run: |
-          sudo apt install -y libhidapi-dev cmake protobuf-compiler python3-protobuf
-          
-          ( cd /usr/local/bin && ln -s `which arm-none-eabi-gcc` arm-none-eabi-gcc )
-          echo "/usr/local/bin" >> $GITHUB_PATH
-
-          # nanopb
-          wget 'https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.5-linux-x86.tar.gz'
-          tar xzf nanopb-0.4.5-linux-x86.tar.gz
-          echo "`pwd`/nanopb-0.4.5-linux-x86/generator-bin" >> $GITHUB_PATH
-
-          # protobuf
-          #wget 'https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-x86_64.zip'
-          #mkdir .local
-          #unzip protoc-3.20.1-linux-x86_64.zip -d .local
-          #echo "`pwd`/.local/bin" >> $GITHUB_PATH
-
-          # protobuf-python
-          #wget 'https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protobuf-python-3.20.1.tar.gz'
-          #tar xzf protobuf-python-3.20.1.tar.gz
-          #cd protobuf-3.20.1/python
-          #python setup.py build
-          #sudo python setup.py install
+        uses: docker/setup-buildx-action@v2
 
       - name: Setup deps for Bitcoin Core
         if: ${{ matrix.project == 'bitcoin-core' }}

--- a/bitbox02-firmware/artifacts.sh
+++ b/bitbox02-firmware/artifacts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DATE=`date +%Y-%m-%d`
+DATE=$(date +%Y-%m-%d)
 TWITTER_NAME="BitBox02"
 URL="https://shiftcrypto.ch/bitbox02/"
 VERSION_STRING="v9.12.0"

--- a/bitbox02-firmware/artifacts.sh
+++ b/bitbox02-firmware/artifacts.sh
@@ -3,11 +3,11 @@
 DATE=`date +%Y-%m-%d`
 TWITTER_NAME="BitBox02"
 URL="https://shiftcrypto.ch/bitbox02/"
-VERSION="firmware-btc-only/v9.12.0"
+VERSION_STRING="v9.12.0"
 REPO="https://github.com/digitalbitbox/bitbox02-firmware"
 CHECKSUM_SOURCE="https://github.com/digitalbitbox/bitbox02-firmware/releases/tag/${VERSION}"
 PROJECT="bitbox02-firmware"
-SHA256=`shasum -a 256 firmware/stm32/firmware-signed.bin | cut -f 1 -d ' '`
+SHA256=$(shasum -a 256 bitbox02-firmware/releases/temp/build/bin/firmware-btc.bin | cut -f 1 -d ' ')
 
 # Note GITHUB_ environment variables are populated by Github Actions
 ARTIFACT_BASEURL="https://github.com/${GITHUB_REPOSITORY}/raw"

--- a/bitbox02-firmware/steps.sh
+++ b/bitbox02-firmware/steps.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 # Pull in version numbers from artifacts.sh
-eval "$(grep VERSION artifacts.sh)"
+eval "$(grep VERSION_STRING artifacts.sh)"
 
-if [ ! -e bitbox02-firmware ] ; then
-  # Checkout source and submodules
-  git clone --progress --recurse-submodules https://github.com/digitalbitbox/bitbox02-firmware
+if [ ! -e bitbox02-firmware ]; then
+	# Checkout source and submodules
+	git clone --progress https://github.com/digitalbitbox/bitbox02-firmware
 fi
 
-cd bitbox02-firmware
-git checkout ${VERSION_STRING}
-
-make firmware
+cd bitbox02-firmware/releases
+./build.sh firmware-btc-only/${VERSION_STRING} "make firmware-btc"
+echo "shasum" $(shasum -a 256 temp/build/bin/firmware-btc.bin)
 
 # Add delay for results to be printed and recorded
 sleep 10


### PR DESCRIPTION
## Why 
Updated the bitbox02 build process. Links to build artifacts [here](https://github.com/caheredia/bitcoinbinary.org/actions/runs/3415334630)

## What
- Added bitbox02 back into github workflow
- Updated build instructions for bitbox
Ouput text:
```html
<li><a href='https://github.com/digitalbitbox/bitbox02-firmware/releases/tag/'>2022-11-08</a> | <a href='https://shiftcrypto.ch/bitbox02/' class='project-name'>bitbox02-firmware</a> | <a href='https://github.com/digitalbitbox/bitbox02-firmware/releases/tag/'></a> | <a href='https://github.com/digitalbitbox/bitbox02-firmware/releases/tag/'> factory 1d3cf66e1b2f91e369a434ee81700323896c7e8c51a79a20de13a3c90099cebd </a>| <a href='https://github.com/caheredia/bitcoinbinary.org/raw/update_bitbox_build/bitbox02-firmware/bitbox02-firmware--video.webm'>video proof</a> | <a href='https://github.com/coinkite/bitcoinbinary.org/blob/main/bitbox02-firmware/artifacts.sh' class=bot>build bot</a></li>
```
<img width="1389" alt="image" src="https://user-images.githubusercontent.com/28638529/200457346-6f28366f-f433-49e5-88bb-bdb71d3bbdca.png">