### PR TITLE
1.0.1Q repro

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,6 +226,15 @@ input:checked + .slider:before {
 <h2>Binary Log:</h2>
 <ul class="log">
     <li>
+         <a href='https://github.com/Coldcard/firmware/commit/e96fe126635b38f798c82ca9b95a2ccac67d4168'>2024-03-14</a> |
+         <a href='https://coldcard.com' class='project-name'>coldcard</a> |
+         <a href='https://github.com/Coldcard/firmware/commit/e96fe126635b38f798c82ca9b95a2ccac67d4168'>v1.0.1Q</a> |
+         <a href="https://x.com/AVirgovic/status/1768385880559948049">tweet</a> |
+         <a href='https://raw.githubusercontent.com/Coldcard/firmware/master/releases/signatures.txt'> factory 6ea843a56e87d7d811d90be6bfa4703794bbc8318d9709e88ada05740e03b12d</a>|
+         <a href='https://youtu.be/ct1iDJLI-j8'>video proof</a> |
+         <a href='https://github.com/coinkite/bitcoinbinary.org/blob/main/coldcard/artifacts.sh' class=bot>build bot</a>
+     </li>
+    <li>
          <a href='https://github.com/Coldcard/firmware/releases/tag/2024-01-18T1507-v6.2.2X'>2024-01-19</a> |
          <a href='https://coldcard.com' class='project-name'>coldcard</a> |
          <a href='https://github.com/Coldcard/firmware/releases/tag/2024-01-18T1507-v6.2.2X'>v6.2.2X</a> |


### PR DESCRIPTION
used commit links instead of tags - as we currently do not have any Q tags in firmware repo (all in qfirmware)